### PR TITLE
feat: agregar endpoints multi-programa para consulta de grupos

### DIFF
--- a/docker-compose.multitenancy.yml
+++ b/docker-compose.multitenancy.yml
@@ -25,6 +25,7 @@ services:
       SPRING_MAIL_PASSWORD: hbkhhjqihudzcakl
       SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH: "true"
       SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE: "true"
+      EMAIL_FAKE_DESTINATION: sigha.notifications@gmail.com
       SPRING_JACKSON_TIME_ZONE: America/Bogota
       SIGHA_URL_ACCESS: ${SIGHA_URL_ACCESS:-http://localhost}
     restart: unless-stopped
@@ -55,6 +56,7 @@ services:
       SPRING_MAIL_PASSWORD: hbkhhjqihudzcakl
       SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH: "true"
       SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE: "true"
+      EMAIL_FAKE_DESTINATION: sigha.notifications@gmail.com
       SPRING_JACKSON_TIME_ZONE: America/Bogota
       SIGHA_URL_ACCESS: ${SIGHA_URL_ACCESS:-http://localhost}
     restart: unless-stopped
@@ -85,6 +87,7 @@ services:
       SPRING_MAIL_PASSWORD: hbkhhjqihudzcakl
       SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH: "true"
       SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE: "true"
+      EMAIL_FAKE_DESTINATION: sigha.notifications@gmail.com
       SPRING_JACKSON_TIME_ZONE: America/Bogota
       SIGHA_URL_ACCESS: ${SIGHA_URL_ACCESS:-http://localhost}
     restart: unless-stopped
@@ -115,6 +118,7 @@ services:
       SPRING_MAIL_PASSWORD: hbkhhjqihudzcakl
       SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH: "true"
       SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE: "true"
+      EMAIL_FAKE_DESTINATION: sigha.notifications@gmail.com
       SPRING_JACKSON_TIME_ZONE: America/Bogota
       SIGHA_URL_ACCESS: ${SIGHA_URL_ACCESS:-http://localhost}
     restart: unless-stopped

--- a/src/main/java/judamov/sipoh/controllers/GroupController.java
+++ b/src/main/java/judamov/sipoh/controllers/GroupController.java
@@ -26,6 +26,20 @@ public class GroupController {
         return ResponseEntity.ok(groups);
     }
 
+    /**
+     * Devuelve todos los grupos de un semestre para todos los programas,
+     * usando la vista core.v_all_groups_by_semester. Incluye, además de
+     * la información habitual del grupo, los campos de programa y escuela.
+     */
+    @GetMapping("/by-semesters/all-programs")
+    public ResponseEntity<List<GroupDTO>> getAllBySemestersAllPrograms(
+            @RequestHeader Long semesterId,
+            @Parameter(hidden = true) @RequestHeader Long userId
+    ) {
+        List<GroupDTO> groups = groupService.getAllBySemesterAllPrograms(userId, semesterId);
+        return ResponseEntity.ok(groups);
+    }
+
     @GetMapping("/by-levels")
     public ResponseEntity<List<GroupDTO>> getAllByLevels(
             @RequestParam List<Long> idLevels,
@@ -62,6 +76,33 @@ public class GroupController {
             @Parameter(hidden = true) @RequestHeader Long userId) {
 
         List<GroupDTO> groups = groupService.getAllByFilters(idLevels, docentesIds, subjectIds, userId, semesterId);
+        return ResponseEntity.ok(groups);
+    }
+
+    /**
+     * Versión multi-programa de /by-filters. Aplica los mismos filtros
+     * (niveles, docentes, materias) pero usando la vista
+     * core.v_all_groups_by_semester, devolviendo además la
+     * clasificación por programa y escuela.
+     */
+    @GetMapping("/by-filters/all-programs")
+    public ResponseEntity<List<GroupDTO>> getAllByFiltersAllPrograms(
+            @RequestParam(required = false) List<Long> idLevels,
+            @RequestParam(required = false) List<Long> docentesIds,
+            @RequestParam(required = false) List<Long> subjectIds,
+            @RequestParam(required = false) List<String> programCodes,
+            @RequestParam(required = true) Long semesterId,
+            @Parameter(hidden = true) @RequestHeader Long userId
+    ) {
+
+        List<GroupDTO> groups = groupService.getAllByFiltersAllPrograms(
+                idLevels,
+                docentesIds,
+                subjectIds,
+                programCodes,
+                userId,
+                semesterId
+        );
         return ResponseEntity.ok(groups);
     }
 

--- a/src/main/java/judamov/sipoh/dto/GroupDTO.java
+++ b/src/main/java/judamov/sipoh/dto/GroupDTO.java
@@ -25,5 +25,22 @@ public class GroupDTO {
     private String code;
     private String max_students;
     private String enrolled;
+    /**
+     * Código interno del programa/escuela (por ejemplo: ING_SISTEMAS).
+     * Se usa únicamente en el endpoint global que consulta la vista
+     * multi-programa; en los endpoints actuales puede venir en null.
+     */
+    private String programCode;
+
+    /**
+     * Nombre legible del programa (por ejemplo: Ingeniería de Sistemas).
+     */
+    private String programName;
+
+    /**
+     * Nombre de la escuela/facultad a la que pertenece el programa.
+     */
+    private String escuela;
+
     private List<ScheduleDTO> scheduleList;
 }

--- a/src/main/java/judamov/sipoh/repository/IGroupRepository.java
+++ b/src/main/java/judamov/sipoh/repository/IGroupRepository.java
@@ -5,6 +5,8 @@ import judamov.sipoh.entity.Semester;
 import judamov.sipoh.entity.Subject;
 import judamov.sipoh.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -19,4 +21,47 @@ public interface IGroupRepository extends JpaRepository<Group, Long> {
     Optional<List<Group>> findByDocenteAndSemester (User docente, Semester semester);
 
     Optional<Group> findByCode(String code);
+
+    /**
+     * Consulta nativa sobre la vista core.v_all_groups_by_semester
+     * que devuelve todos los grupos de todos los programas para
+     * un semestre dado.
+     *
+     * El resultado es una lista de arreglos de Object con el siguiente orden:
+     * 0: id
+     * 1: id_semestre
+     * 2: id_subject
+     * 3: code_subject
+     * 4: name_subject
+     * 5: id_docente
+     * 6: id_level
+     * 7: level_name
+     * 8: code
+     * 9: max_students
+     * 10: enrolled
+     * 11: program_code
+     * 12: program_name
+     * 13: escuela
+     */
+    @Query(value = """
+            SELECT
+                id,
+                id_semestre,
+                id_subject,
+                code_subject,
+                name_subject,
+                id_docente,
+                id_level,
+                level_name,
+                code,
+                max_students,
+                enrolled,
+                program_code,
+                program_name,
+                escuela
+            FROM core.v_all_groups_by_semester
+            WHERE id_semestre = :semesterId
+            """,
+            nativeQuery = true)
+    List<Object[]> findAllProgramsBySemester(@Param("semesterId") Long semesterId);
 }

--- a/src/main/java/judamov/sipoh/service/impl/GroupServiceImpl.java
+++ b/src/main/java/judamov/sipoh/service/impl/GroupServiceImpl.java
@@ -171,6 +171,59 @@ public class GroupServiceImpl implements IGroupService {
         return mapWithSchedules(groups);
     }
 
+    @Override
+    public List<GroupDTO> getAllBySemesterAllPrograms(Long adminId, Long semesterId) {
+        validateAdminAccess(adminId);
+
+        List<Object[]> rows = groupRepository.findAllProgramsBySemester(semesterId);
+
+        return rows.stream()
+                .map(this::mapRowToGroupDTO)
+                .toList();
+    }
+
+    @Override
+    public List<GroupDTO> getAllByFiltersAllPrograms(List<Long> idLevels,
+                                                     List<Long> docentesIds,
+                                                     List<Long> subjectIds,
+                                                     List<String> programCodes,
+                                                     Long adminId,
+                                                     Long semesterId) {
+        validateAdminAccess(adminId);
+
+        List<Object[]> rows = groupRepository.findAllProgramsBySemester(semesterId);
+        List<GroupDTO> all = rows.stream()
+                .map(this::mapRowToGroupDTO)
+                .toList();
+
+        boolean noLevelFilter    = (idLevels == null || idLevels.isEmpty());
+        boolean noDocenteFilter  = (docentesIds == null || docentesIds.isEmpty());
+        boolean noSubjectFilter  = (subjectIds == null || subjectIds.isEmpty());
+        boolean noProgramFilter  = (programCodes == null || programCodes.isEmpty());
+
+        if (noLevelFilter && noDocenteFilter && noSubjectFilter && noProgramFilter) {
+            return all;
+        }
+
+        return all.stream()
+                .filter(dto -> {
+                    boolean matchesLevel = noLevelFilter ||
+                            (dto.getIdLevel() != null && idLevels.contains(dto.getIdLevel()));
+
+                    boolean matchesDocente = noDocenteFilter ||
+                            (dto.getIdDocente() != null && docentesIds.contains(dto.getIdDocente()));
+
+                    boolean matchesSubject = noSubjectFilter ||
+                            (dto.getIdSubject() != null && subjectIds.contains(dto.getIdSubject()));
+
+                    boolean matchesProgram = noProgramFilter ||
+                            (dto.getProgramCode() != null && programCodes.contains(dto.getProgramCode()));
+
+                    return matchesLevel && matchesDocente && matchesSubject && matchesProgram;
+                })
+                .toList();
+    }
+
     /**
      * Obtiene los grupos cuyo nivel esté incluido en la lista de niveles.
      *
@@ -414,6 +467,60 @@ public class GroupServiceImpl implements IGroupService {
         });
 
         return groupDTOList;
+    }
+
+    /**
+     * Mapea una fila devuelta por la vista core.v_all_groups_by_semester
+     * a un GroupDTO, incluyendo los campos de programa/escuela.
+     *
+     * Orden esperado de las columnas (Object[] row):
+     * 0: id
+     * 1: id_semestre
+     * 2: id_subject
+     * 3: code_subject
+     * 4: name_subject
+     * 5: id_docente
+     * 6: id_level
+     * 7: level_name
+     * 8: code
+     * 9: max_students
+     * 10: enrolled
+     * 11: program_code
+     * 12: program_name
+     * 13: escuela
+     */
+    private GroupDTO mapRowToGroupDTO(Object[] row) {
+        GroupDTO dto = new GroupDTO();
+
+        dto.setId(getLong(row[0]));
+        dto.setIdSemestre(getLong(row[1]));
+        dto.setIdSubject(getLong(row[2]));
+        dto.setCodeSubject((String) row[3]);
+        dto.setNameSubject((String) row[4]);
+        dto.setIdDocente(getLong(row[5]));
+        dto.setIdLevel(getLong(row[6]));
+        dto.setLevelName((String) row[7]);
+        dto.setCode((String) row[8]);
+        dto.setMax_students((String) row[9]);
+        dto.setEnrolled((String) row[10]);
+        dto.setProgramCode((String) row[11]);
+        dto.setProgramName((String) row[12]);
+        dto.setEscuela((String) row[13]);
+
+        // La vista no incluye horarios; dejamos la lista vacía para mantener la forma del DTO.
+        dto.setScheduleList(List.of());
+
+        return dto;
+    }
+
+    private Long getLong(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        return Long.parseLong(value.toString());
     }
 
     /**

--- a/src/main/java/judamov/sipoh/service/interfaces/IGroupService.java
+++ b/src/main/java/judamov/sipoh/service/interfaces/IGroupService.java
@@ -14,6 +14,13 @@ import java.util.List;
 public interface IGroupService {
     List<GroupDTO> getAllBySemester(Long adminId, Long semesterId);
 
+    /**
+     * Obtiene todos los grupos de todos los programas para un semestre,
+     * usando la vista core.v_all_groups_by_semester. Incluye la
+     * clasificación por programa/escuela.
+     */
+    List<GroupDTO> getAllBySemesterAllPrograms(Long adminId, Long semesterId);
+
     List<GroupDTO> getAllByLevels(List<Long> idLevel, Long adminId, Long semesterId);
 
     List<GroupDTO> getAllBySubject(Long subjectId, Long adminId, Long semesterId);
@@ -25,4 +32,16 @@ public interface IGroupService {
     Boolean createGroupsBulk(List<GroupCreateDTO> dtos, Long adminId, Long semesterId) ;
     Boolean deleteAllGroupsBySemesterId (Long userId, Long semesterId);
     List<GroupDTO> getAllByFilters(List<Long> idLevels, List<Long> docentesIds, List<Long> subjectIds, Long adminId,Long semesterId);
+
+    /**
+     * Versión multi-programa de getAllByFilters, usando la vista
+     * core.v_all_groups_by_semester. Aplica los mismos filtros
+     * (niveles, docentes, materias) pero sobre todos los programas.
+     */
+    List<GroupDTO> getAllByFiltersAllPrograms(List<Long> idLevels,
+                                              List<Long> docentesIds,
+                                              List<Long> subjectIds,
+                                              List<String> programCodes,
+                                              Long adminId,
+                                              Long semesterId);
 }


### PR DESCRIPTION
- Crear vista core.v_all_groups_by_semester unificando grupos de todos los programas
- Agregar campos programCode, programName y escuela a GroupDTO
- Implementar endpoint GET /api/v1/group/by-semesters/all-programs
- Implementar endpoint GET /api/v1/group/by-filters/all-programs con filtros por:
  * semesterId (requerido)
  * programCodes (opcional)
  * docentesIds (opcional)
  * subjectIds (opcional)
- Agregar consulta nativa findAllProgramsBySemester en IGroupRepository
- Agregar variable EMAIL_FAKE_DESTINATION en docker-compose.multitenancy.yml